### PR TITLE
Sonarr Missing episodes column ordering is incorrect

### DIFF
--- a/varken/sonarr.py
+++ b/varken/sonarr.py
@@ -55,7 +55,7 @@ class SonarrAPI(object):
                 downloaded = 0
             if query == "Missing":
                 if not downloaded:
-                    missing.append((show.series['title'], downloaded, sxe, show.airDateUtc, show.title, show.id))
+                    missing.append((show.series['title'], downloaded, sxe, show.title, show.airDateUtc, show.id))
             else:
                 air_days.append((show.series['title'], downloaded, sxe, show.title, show.airDateUtc, show.id))
 


### PR DESCRIPTION
Fix data for missing episodes in Sonarr. Currently episode name is stored in air time and vice versa.